### PR TITLE
Refactor assert in `look_pre` routine to use `numberIsNotNan` instead…

### DIFF
--- a/proto/wtools/abase/l2/Looker.s
+++ b/proto/wtools/abase/l2/Looker.s
@@ -1110,7 +1110,7 @@ function look_pre( routine, args )
   _.assert( arguments.length === 2, 'Expects exactly two arguments' );
   _.assert( o.onUp === null || o.onUp.length === 0 || o.onUp.length === 3, 'onUp should expect exactly three arguments' );
   _.assert( o.onDown === null || o.onDown.length === 0 || o.onDown.length === 3, 'onDown should expect exactly three arguments' );
-  _.assert( _.intIs( o.recursive ), 'Expects integer {- o.recursive -}' );
+  _.assert( _.numberIsNotNan( o.recursive ), 'Expects number {- o.recursive -}' );
 
   if( o.Looker === null )
   o.Looker = Looker;


### PR DESCRIPTION
… of `intIs`